### PR TITLE
Remove crx.gg from vendors

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Got suggestions/updates for this sheet, add them [HERE](https://forms.gle/qAR3ny
 **Pre-builts and Parts**
 
  - [https://www.amazon.in/](https://www.amazon.in/ "https://www.amazon.in/")
- - [https://crx.gg/](https://crx.gg/ "https://crx.gg/") 
  - [https://keychron.in/](https://keychron.in/ "https://keychron.in/") 
  - [https://www.genesispc.in/](https://www.genesispc.in/ "https://www.genesispc.in/")  
  - [https://www.meckeys.com/](https://www.meckeys.com/ "https://www.meckeys.com/")


### PR DESCRIPTION
The crx.gg domain is on sale. Assuming they are no longer functional